### PR TITLE
Fix a small mistake of condition in UVConverter

### DIFF
--- a/UVTextureConverter/UVConverter.py
+++ b/UVTextureConverter/UVConverter.py
@@ -140,7 +140,7 @@ class UVConverter(object):
         if isinstance(im, str) and isinstance(iuv, str):
             im = Image.open(im)
             iuv = Image.open(iuv)
-        elif isinstance(im, type(Image)) and isinstance(iuv, type(Image)):
+        elif isinstance(im, Image.Image) and isinstance(iuv, Image.Image):
             im = im
             iuv = iuv
         elif isinstance(im, np.ndarray) and isinstance(iuv, np.ndarray):


### PR DESCRIPTION
Thank you for creating this great library! 

I found an error when I was running `notebooks/create_uv_texture_from_image_by_using_densepose.ipynb`.
When I changed the 5th cell to input PIL.Image as an argument, 
```python
# tex_trans: (24, 200, 200, 3), mask_trans: (24, 200, 200)
tex_trans, mask_trans = UVConverter.create_texture(im, iuv, parts_size=parts_size, concat=False)

# for display
tex = UVConverter.concat_atlas_tex(tex_trans)  # 800 x 1200 x 3
mask = UVConverter.concat_atlas_tex(mask_trans)  # 800 x 1200
```

I got an error.
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-5-aafd4a4228fa> in <module>
      1 # tex_trans: (24, 200, 200, 3), mask_trans: (24, 200, 200)
----> 2 tex_trans, mask_trans = UVConverter.create_texture(im, iuv, parts_size=parts_size, concat=False)
      3 
      4 # for display
      5 tex = UVConverter.concat_atlas_tex(tex_trans)  # 800 x 1200 x 3

~/.local/lib/python3.8/site-packages/UVTextureConverter/UVConverter.py in create_texture(cls, im, iuv, parts_size, concat)
    173     @classmethod
    174     def create_texture(cls, im, iuv, parts_size=200, concat=True):
--> 175         tex, mask = cls.create_smpl_from_images(im, iuv, img_size=parts_size)
    176         tex_trans = np.zeros((24, parts_size, parts_size, 3))
    177         mask_trans = np.zeros((24, parts_size, parts_size))

~/.local/lib/python3.8/site-packages/UVTextureConverter/UVConverter.py in create_smpl_from_images(cls, im, iuv, img_size)
    148             iuv = Image.fromarray(np.uint8(iuv * 255))
    149         else:
--> 150             raise ValueError('im and iuv must be str or PIL.Image or np.ndarray.')
    151 
    152         im = (np.array(im) / 255).transpose(2, 1, 0)

ValueError: im and iuv must be str or PIL.Image or np.ndarray.
```


This is due to the type check of `isinstance(iuv, type(Image))` at L143 in `UVTextureConverter/UVConverter.py`.
Type check of PIL.Image should be `isinstance(img, Image.Image)`.

```python
img = Image.fromarray(np.zeros((512,512)))
print(type(Image))
print(img)
print("current:", isinstance(img, type(Image)))
print("fix:", isinstance(img, Image.Image))
```

```
<class 'module'>
<PIL.Image.Image image mode=F size=512x512 at 0x7F65DD59D310>
current: False
fix: True
```

I have checked the modified version of `notebooks/create_uv_texture_from_image_by_using_densepose.ipynb` works with this PR.

